### PR TITLE
feat: merge WezTerm configs with improved settings

### DIFF
--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -95,7 +95,7 @@ config.keys = {
     mods = "SUPER",
     action = act.SpawnCommandInNewWindow({
       cwd = os.getenv("WEZTERM_CONFIG_DIR"),
-      args = { os.getenv("SHELL"), "-c", "$EDITOR $WEZTERM_CONFIG_FILE" },
+      args = { os.getenv("SHELL"), "-c", "${EDITOR:-cursor} $WEZTERM_CONFIG_FILE || ${EDITOR:-code} $WEZTERM_CONFIG_FILE || vim $WEZTERM_CONFIG_FILE" },
     }),
   },
 }

--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -1,86 +1,121 @@
 -- Pull in the wezterm API
 local wezterm = require("wezterm")
+local act = wezterm.action
 
 -- This will hold the configuration.
 local config = wezterm.config_builder()
 
--- This is where you actually apply your config choices
-
+-- Core appearance settings
 config.font = wezterm.font("MesloLGS Nerd Font Mono")
 config.font_size = 19
+config.color_scheme = "tokyonight_night"
+config.enable_tab_bar = true
+config.window_decorations = "INTEGRATED_BUTTONS|RESIZE"
+config.window_background_opacity = 0.8
+config.macos_window_background_blur = 20
 
-config.color_scheme = 'tokyonight_night'
+-- Advanced features
 config.pane_focus_follows_mouse = true
 config.scrollback_lines = 100000
 
-config.enable_tab_bar = false
+-- Task completion notifications using user variables
+wezterm.on('user-var-changed', function(window, pane, name, value)
+  if name == 'wez_notify' then
+    window:toast_notification('WezTerm', value, nil, 4000)
+  end
+end)
 
-config.window_decorations = "INTEGRATED_BUTTONS|RESIZE"
-
-config.window_background_opacity = 0.8
-config.macos_window_background_blur = 10
-
+-- Key bindings (merged from both configs)
 config.keys = {
+  -- Pane management (from GitHub)
   {
-    key = 'd',
-    mods = 'CMD',
-    action = wezterm.action.SplitHorizontal { domain = 'CurrentPaneDomain' },
+    key = "d",
+    mods = "CMD",
+    action = act.SplitHorizontal { domain = "CurrentPaneDomain" },
   },
   {
-    key = 'd',
-    mods = 'CMD|SHIFT',
-    action = wezterm.action.SplitVertical { domain = 'CurrentPaneDomain' },
+    key = "d",
+    mods = "CMD|SHIFT",
+    action = act.SplitVertical { domain = "CurrentPaneDomain" },
+  },
+
+  -- Pane navigation (from GitHub)
+  {
+    key = "LeftArrow",
+    mods = "CMD",
+    action = act.ActivatePaneDirection("Prev"),
   },
   {
-    key="LeftArrow",
-    mods="OPT",
-    action=wezterm.action{SendString="\x1bb"}
+    key = "RightArrow",
+    mods = "CMD",
+    action = act.ActivatePaneDirection("Next"),
+  },
+
+  -- Tab navigation (from GitHub)
+  {
+    key = "LeftArrow",
+    mods = "CMD|OPT",
+    action = act.ActivateTabRelative(-1),
   },
   {
-    key="RightArrow",
-    mods="OPT",
-    action=wezterm.action{SendString="\x1bf"}
+    key = "RightArrow",
+    mods = "CMD|OPT",
+    action = act.ActivateTabRelative(1),
+  },
+
+  -- Word navigation (from both configs)
+  {
+    key = "LeftArrow",
+    mods = "OPT",
+    action = act.SendString("\x1bb"),
   },
   {
-    key = 'LeftArrow',
-    mods = 'CMD|OPT',
-    action = wezterm.action.ActivateTabRelative(-1)
+    key = "RightArrow",
+    mods = "OPT",
+    action = act.SendString("\x1bf"),
   },
+
+  -- Vim integration (from GitHub)
   {
-    key = 'RightArrow',
-    mods = 'CMD|OPT',
-    action = wezterm.action.ActivateTabRelative(1)
+    key = "s",
+    mods = "CMD",
+    action = act.SendString("\x1b:w\n"),
   },
+
+  -- Multi-line input (from local)
   {
-    key = 'LeftArrow',
-    mods = 'CMD',
-    action = wezterm.action{ActivatePaneDirection='Prev'},
+    key = "Enter",
+    mods = "SHIFT",
+    action = act.SendString("\x1b\r"),
   },
+
+  -- Quick config editing (from local)
   {
-    key = 'RightArrow',
-    mods = 'CMD',
-    action = wezterm.action{ActivatePaneDirection='Next'},
-  },
-  {
-    key="s",
-    mods="CMD",
-    action = wezterm.action{SendString="\x1b:w\n"}
+    key = ",",
+    mods = "SUPER",
+    action = act.SpawnCommandInNewWindow({
+      cwd = os.getenv("WEZTERM_CONFIG_DIR"),
+      args = { os.getenv("SHELL"), "-c", "$EDITOR $WEZTERM_CONFIG_FILE" },
+    }),
   },
 }
 
+-- Mouse bindings (from GitHub)
 config.mouse_bindings = {
+  -- Block selection with Cmd+Alt+Click
   {
-    event = { Down = { streak = 1, button = 'Left' } },
-    mods = 'CMD|ALT',
-    action = wezterm.action.SelectTextAtMouseCursor 'Block',
-    alt_screen='Any'
+    event = { Down = { streak = 1, button = "Left" } },
+    mods = "CMD|ALT",
+    action = act.SelectTextAtMouseCursor("Block"),
+    alt_screen = "Any",
   },
+  -- Semantic zone selection with 4-click
   {
-    event = { Down = { streak = 4, button = 'Left' } },
-    action = wezterm.action.SelectTextAtMouseCursor 'SemanticZone',
-    mods = 'NONE',
+    event = { Down = { streak = 4, button = "Left" } },
+    action = act.SelectTextAtMouseCursor("SemanticZone"),
+    mods = "NONE",
   },
 }
 
--- and finally, return the configuration to wezterm
+-- Return the configuration to wezterm
 return config

--- a/README.md
+++ b/README.md
@@ -1,11 +1,80 @@
-# setup
+# Development Environment Setup
 
-Great tutorial to setup wezterm https://www.josean.com/posts/how-to-setup-wezterm-terminal
+Personal configuration files for development tools and terminal setup.
 
-iterm setup https://gist.github.com/GLMeece/4b51037daa0d6b83256f80b560246f38
+## WezTerm Configuration
 
-Ignore untracked files locally
+This repository includes a comprehensive WezTerm configuration with advanced features.
+
+### Setup Instructions
+
+```bash
+# Copy WezTerm config to your home directory
+cp .wezterm.lua ~/.wezterm.lua
+```
+
+WezTerm will automatically reload when you save the config file.
+
+### Features
+
+**Visual Appearance:**
+- Font: MesloLGS Nerd Font Mono (size 19)
+- Color scheme: tokyonight_night
+- Window opacity: 80% with macOS blur effect (blur level: 20)
+- Integrated window control buttons (minimize, maximize, close)
+- Tab bar enabled
+- Large scrollback buffer: 100,000 lines
+
+**Pane Management:**
+- `Cmd+D` - Split pane horizontally
+- `Cmd+Shift+D` - Split pane vertically
+- `Cmd+Left/Right Arrow` - Navigate between panes
+- Mouse focus follows pointer automatically
+
+**Tab Navigation:**
+- `Cmd+Option+Left/Right Arrow` - Switch between tabs
+
+**Text Navigation:**
+- `Option+Left/Right Arrow` - Jump backward/forward by word
+
+**Editor Integration:**
+- `Cmd+S` - Save in vim (sends `:w\n`)
+- `Shift+Enter` - Multi-line input handling
+
+**Configuration:**
+- `Cmd+,` - Quick access to open config file
+
+**Mouse Features:**
+- `Cmd+Alt+Click` - Block text selection mode
+- `4-click` - Semantic zone selection (selects entire logical block)
+
+**Task Notifications:**
+- Terminal can send desktop notifications via `wez_notify` user variable
+
+### Customization
+
+To change the color scheme, modify this line in `.wezterm.lua`:
+```lua
+config.color_scheme = "tokyonight_night"
+```
+
+WezTerm includes 735+ built-in color schemes. Popular alternatives: `Batman`, `Dracula`, `Nord`, `Solarized Dark`.
+
+### References
+
+**WezTerm Setup:**
+- Great tutorial: https://www.josean.com/posts/how-to-setup-wezterm-terminal
+- Official docs: https://wezterm.org/config/files.html
+
+## iTerm Setup
+
+Alternative setup guide: https://gist.github.com/GLMeece/4b51037daa0d6b83256f80b560246f38
+
+## Git Tips
+
+**Ignore untracked files locally:**
 https://stackoverflow.com/a/1753078
 
-#### Ios Development:
-https://docs.cursor.com/guides/languages/swift
+## iOS Development
+
+Swift language support in Cursor: https://docs.cursor.com/guides/languages/swift


### PR DESCRIPTION
## Summary
Merged local and GitHub WezTerm configurations to create a comprehensive terminal setup with all features from both versions.

## Changes
- **Enhanced blur effect**: Increased macOS window blur from 10 to 20 for better aesthetics
- **Tab bar enabled**: Works well with integrated window control buttons
- **Task notifications**: Added desktop notification support via `wez_notify` user variable
- **Quick config access**: New `Cmd+,` keybinding to instantly open config file
- **Multi-line input**: Added `Shift+Enter` support for better shell interaction

## Features Retained
- ✅ Advanced pane management (Cmd+D horizontal split, Cmd+Shift+D vertical split)
- ✅ Pane navigation (Cmd+Left/Right arrows)
- ✅ Tab navigation (Cmd+Option+Left/Right arrows)
- ✅ Vim integration (Cmd+S sends `:w\n`)
- ✅ Mouse features (Cmd+Alt+Click for block selection, 4-click for semantic zones)
- ✅ Focus follows mouse
- ✅ 100K scrollback buffer

## Documentation
Updated README.md with:
- Complete setup instructions
- Detailed feature list with all keybindings
- Customization tips (color schemes, etc.)
- Reference links to official docs

## Test Plan
- [x] Merged config tested locally with all keybindings
- [x] Window control buttons visible and functional
- [x] Pane splitting and navigation working
- [x] Tab navigation working
- [x] Quick config access (Cmd+,) working
- [x] Visual appearance (blur, opacity, tab bar) as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)